### PR TITLE
kernel/server_session: Add IsSession() member function

### DIFF
--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -152,7 +152,7 @@ ResultCode ServerSession::HandleSyncRequest(SharedPtr<Thread> thread) {
     // Handle scenario when ConvertToDomain command was issued, as we must do the conversion at the
     // end of the command such that only commands following this one are handled as domains
     if (convert_to_domain) {
-        ASSERT_MSG(domain_request_handlers.empty(), "already a domain");
+        ASSERT_MSG(IsSession(), "ServerSession is already a domain instance.");
         domain_request_handlers = {hle_handler};
         convert_to_domain = false;
     }

--- a/src/core/hle/kernel/server_session.h
+++ b/src/core/hle/kernel/server_session.h
@@ -97,7 +97,12 @@ public:
 
     /// Returns true if the session has been converted to a domain, otherwise False
     bool IsDomain() const {
-        return !domain_request_handlers.empty();
+        return !IsSession();
+    }
+
+    /// Returns true if this session has not been converted to a domain, otherwise false.
+    bool IsSession() const {
+        return domain_request_handlers.empty();
     }
 
     /// Converts the session to a domain at the end of the current command

--- a/src/core/hle/service/sm/controller.cpp
+++ b/src/core/hle/service/sm/controller.cpp
@@ -10,7 +10,7 @@
 namespace Service::SM {
 
 void Controller::ConvertSessionToDomain(Kernel::HLERequestContext& ctx) {
-    ASSERT_MSG(!ctx.Session()->IsDomain(), "session is alread a domain");
+    ASSERT_MSG(ctx.Session()->IsSession(), "Session is already a domain");
     ctx.Session()->ConvertToDomain();
 
     IPC::ResponseBuilder rb{ctx, 3};


### PR DESCRIPTION
Allows querying the inverse of IsDomain() to make things more readable.
This will likely also be usable in the event of implementing
ConvertDomainToSession().