### PR TITLE
Added various bluetooth based cmds for palma

### DIFF
--- a/src/core/hle/service/btdrv/btdrv.cpp
+++ b/src/core/hle/service/btdrv/btdrv.cpp
@@ -2,11 +2,48 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/logging/log.h"
+#include "core/hle/ipc_helpers.h"
+#include "core/hle/kernel/event.h"
+#include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/service/btdrv/btdrv.h"
 #include "core/hle/service/service.h"
 #include "core/hle/service/sm/sm.h"
 
 namespace Service::BtDrv {
+
+class Bt final : public ServiceFramework<Bt> {
+public:
+    explicit Bt() : ServiceFramework{"bt"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "Unknown0"},
+            {1, nullptr, "Unknown1"},
+            {2, nullptr, "Unknown2"},
+            {3, nullptr, "Unknown3"},
+            {4, nullptr, "Unknown4"},
+            {5, nullptr, "Unknown5"},
+            {6, nullptr, "Unknown6"},
+            {7, nullptr, "Unknown7"},
+            {8, nullptr, "Unknown8"},
+            {9, &Bt::RegisterEvent, "RegisterEvent"},
+        };
+        // clang-format on
+        RegisterHandlers(functions);
+    }
+
+private:
+    void RegisterEvent(Kernel::HLERequestContext& ctx) {
+        auto& kernel = Core::System::GetInstance().Kernel();
+        register_event =
+            Kernel::Event::Create(kernel, Kernel::ResetType::OneShot, "BT:RegisterEvent");
+        IPC::ResponseBuilder rb{ctx, 2, 1};
+        rb.Push(RESULT_SUCCESS);
+        rb.PushCopyObjects(register_event);
+        LOG_WARNING(Service_BTM, "(STUBBED) called");
+    }
+    Kernel::SharedPtr<Kernel::Event> register_event;
+};
 
 class BtDrv final : public ServiceFramework<BtDrv> {
 public:
@@ -67,6 +104,7 @@ public:
 
 void InstallInterfaces(SM::ServiceManager& sm) {
     std::make_shared<BtDrv>()->InstallAsService(sm);
+    std::make_shared<Bt>()->InstallAsService(sm);
 }
 
 } // namespace Service::BtDrv

--- a/src/core/hle/service/btm/btm.cpp
+++ b/src/core/hle/service/btm/btm.cpp
@@ -6,12 +6,117 @@
 
 #include "common/logging/log.h"
 #include "core/hle/ipc_helpers.h"
+#include "core/hle/kernel/event.h"
 #include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/service/btm/btm.h"
 #include "core/hle/service/service.h"
-#include "core/hle/service/sm/sm.h"
 
 namespace Service::BTM {
+
+class IBtmUserCore final : public ServiceFramework<IBtmUserCore> {
+public:
+    explicit IBtmUserCore() : ServiceFramework{"IBtmUserCore"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, &IBtmUserCore::GetScanEvent, "GetScanEvent"},
+            {1, nullptr, "Unknown1"},
+            {2, nullptr, "Unknown2"},
+            {3, nullptr, "Unknown3"},
+            {4, nullptr, "Unknown4"},
+            {5, nullptr, "Unknown5"},
+            {6, nullptr, "Unknown6"},
+            {7, nullptr, "Unknown7"},
+            {8, nullptr, "Unknown8"},
+            {9, nullptr, "Unknown9"},
+            {10, nullptr, "Unknown10"},
+            {17, &IBtmUserCore::GetConnectionEvent, "GetConnectionEvent"},
+            {18, nullptr, "Unknown18"},
+            {19, nullptr, "Unknown19"},
+            {20, nullptr, "Unknown20"},
+            {21, nullptr, "Unknown21"},
+            {22, nullptr, "Unknown22"},
+            {23, nullptr, "Unknown23"},
+            {24, nullptr, "Unknown24"},
+            {25, nullptr, "Unknown25"},
+            {26, &IBtmUserCore::GetDiscoveryEvent, "AcquireBleServiceDiscoveryEventImpl"},
+            {27, nullptr, "Unknown27"},
+            {28, nullptr, "Unknown28"},
+            {29, nullptr, "Unknown29"},
+            {30, nullptr, "Unknown30"},
+            {31, nullptr, "Unknown31"},
+            {32, nullptr, "Unknown32"},
+            {33, &IBtmUserCore::GetConfigEvent, "GetConfigEvent"},
+            {34, nullptr, "Unknown34"},
+            {35, nullptr, "Unknown35"},
+            {36, nullptr, "Unknown36"},
+            {37, nullptr, "Unknown37"},
+        };
+        // clang-format on
+        RegisterHandlers(functions);
+    }
+
+private:
+    void GetScanEvent(Kernel::HLERequestContext& ctx) {
+        auto& kernel = Core::System::GetInstance().Kernel();
+        scan_event =
+            Kernel::Event::Create(kernel, Kernel::ResetType::OneShot, "IBtmUserCore:ScanEvent");
+        IPC::ResponseBuilder rb{ctx, 2, 1};
+        rb.Push(RESULT_SUCCESS);
+        rb.PushCopyObjects(scan_event);
+        LOG_WARNING(Service_BTM, "(STUBBED) called");
+    }
+    void GetConnectionEvent(Kernel::HLERequestContext& ctx) {
+        auto& kernel = Core::System::GetInstance().Kernel();
+        connection_event = Kernel::Event::Create(kernel, Kernel::ResetType::OneShot,
+                                                 "IBtmUserCore:ConnectionEvent");
+        IPC::ResponseBuilder rb{ctx, 2, 1};
+        rb.Push(RESULT_SUCCESS);
+        rb.PushCopyObjects(connection_event);
+        LOG_WARNING(Service_BTM, "(STUBBED) called");
+    }
+    void GetDiscoveryEvent(Kernel::HLERequestContext& ctx) {
+        auto& kernel = Core::System::GetInstance().Kernel();
+        service_discovery =
+            Kernel::Event::Create(kernel, Kernel::ResetType::OneShot, "IBtmUserCore:Discovery");
+        IPC::ResponseBuilder rb{ctx, 2, 1};
+        rb.Push(RESULT_SUCCESS);
+        rb.PushCopyObjects(service_discovery);
+        LOG_WARNING(Service_BTM, "(STUBBED) called");
+    }
+    void GetConfigEvent(Kernel::HLERequestContext& ctx) {
+        auto& kernel = Core::System::GetInstance().Kernel();
+        config_event =
+            Kernel::Event::Create(kernel, Kernel::ResetType::OneShot, "IBtmUserCore:ConfigEvent");
+        IPC::ResponseBuilder rb{ctx, 2, 1};
+        rb.Push(RESULT_SUCCESS);
+        rb.PushCopyObjects(config_event);
+        LOG_WARNING(Service_BTM, "(STUBBED) called");
+    }
+    Kernel::SharedPtr<Kernel::Event> scan_event;
+    Kernel::SharedPtr<Kernel::Event> connection_event;
+    Kernel::SharedPtr<Kernel::Event> service_discovery;
+    Kernel::SharedPtr<Kernel::Event> config_event;
+};
+
+class BTM_USR final : public ServiceFramework<BTM_USR> {
+public:
+    explicit BTM_USR() : ServiceFramework{"btm:u"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, &BTM_USR::GetCoreImpl, "GetCoreImpl"},
+        };
+        // clang-format on
+        RegisterHandlers(functions);
+    }
+
+private:
+    void GetCoreImpl(Kernel::HLERequestContext& ctx) {
+        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        rb.Push(RESULT_SUCCESS);
+        rb.PushIpcInterface<IBtmUserCore>();
+        LOG_DEBUG(Service_BTM, "called");
+    }
+};
 
 class BTM final : public ServiceFramework<BTM> {
 public:
@@ -116,6 +221,7 @@ void InstallInterfaces(SM::ServiceManager& sm) {
     std::make_shared<BTM>()->InstallAsService(sm);
     std::make_shared<BTM_DBG>()->InstallAsService(sm);
     std::make_shared<BTM_SYS>()->InstallAsService(sm);
+    std::make_shared<BTM_USR>()->InstallAsService(sm);
 }
 
 } // namespace Service::BTM


### PR DESCRIPTION
It seems palma is done through bluetooth, we need this for pokemon go however more research needs to be done when we actually get palma working. This is presumably used for transfering data between the controller and the console, it does not seem for actual input as far as I know.